### PR TITLE
Fix - add security to admin pages

### DIFF
--- a/src/main/java/project/app/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/project/app/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,46 @@
+package project.app.interceptor;
+
+import java.util.Map;
+
+import com.opensymphony.xwork2.Action;
+import com.opensymphony.xwork2.ActionInvocation;
+import com.opensymphony.xwork2.interceptor.Interceptor;
+
+import project.app.model.AppConstants;
+
+public class AuthenticationInterceptor implements Interceptor {
+
+    public void destroy() {
+	}
+
+	public void init() {
+	}
+
+	public String intercept( ActionInvocation actionInvocation ) throws Exception {
+
+		Map<String, Object> session = actionInvocation.getInvocationContext().getSession();
+      
+		String role = (String) session.get(AppConstants.USER_SESSION_ROLE);
+
+        String actionName = actionInvocation.getInvocationContext().getName();
+
+        String actionNamespace = actionInvocation.getProxy().getNamespace();
+
+        switch(actionName) {
+            case "index" :
+            case "register": 
+            case "login": 
+            case "registerUser":
+            case "loginAccount": break;
+            default: {
+                if (role == null) {
+                    return Action.LOGIN;
+                } else if (role.equals("Regular") && actionNamespace.contains("/admin") ) {
+                    return "unauthorized";
+                }
+            }
+        }	
+        
+        return actionInvocation.invoke();
+	}
+}

--- a/src/main/java/project/app/model/AppConstants.java
+++ b/src/main/java/project/app/model/AppConstants.java
@@ -2,6 +2,7 @@ package project.app.model;
 
 public interface AppConstants {
 	
+	public static final String USER_SESSION_ROLE = "role";
 	public static final String RULES = "interceptorRules";
 	public static final String RULE_NAME_MAX_BORROW_LIMIT = "Max Borrow Limit";
 	public static final String RULE_NAME_MAX_BORROW_DURATION = "Max Borrow Duration";

--- a/src/main/resources/struts.xml
+++ b/src/main/resources/struts.xml
@@ -12,46 +12,54 @@
     <constant name="struts.freemarker.templatesCache.updateDelay" value="120"/>
     <constant name="struts.freemarker.mru.max.strong.size" value="120"/>
 
-    <package name="rulesFetchDefault" namespace="/" extends="struts-default">
+    <package name="globalsPackage" extends="struts-default">
+    	<global-results>
+            <result name="login" type="redirect">/index</result>
+            <result name="unauthorized" type="redirect">/catalog</result>
+		</global-results>
+    </package>
+    
+    <package name="securePackage" extends="globalsPackage">
+
 		<interceptors>
+			<interceptor name="authenticationInterceptor"
+				class="project.app.interceptor.AuthenticationInterceptor">
+            </interceptor>
 
-			<interceptor name="rulesInterceptor"
-				class="project.app.interceptor.RulesInterceptor" />
-
-			<interceptor-stack name="rulesFetchStack">
+			<interceptor-stack name="secureStack">
+				<interceptor-ref name="authenticationInterceptor" />
 				<interceptor-ref name="defaultStack" />
-                <interceptor-ref name="rulesInterceptor" />
 			</interceptor-stack>
 
 		</interceptors>
 
-		<default-interceptor-ref name="rulesFetchStack" />
-
-        <action name="book" class="project.app.action.Book" method="execute">
-            <result name="success">pages/book.jsp</result>
-        </action>
-
+		<default-interceptor-ref name="secureStack" />
     </package>
 
-    <package name="app" namespace="/" extends="struts-default">
+    <package name="app" namespace="/" extends="securePackage">
+        <!-- action's name used by AuthenticationInterceptor  -->
         <action name="index">
             <result>index.jsp</result>
         </action>
         
+        <!-- action's name used by AuthenticationInterceptor  -->
         <action name="register" class="project.app.action.Register" method="execute">
             <result name="success">pages/register.jsp</result>
         </action>
 
+        <!-- action's name used by AuthenticationInterceptor  -->
         <action name="registerUser" class="project.app.action.Register" method="registerUser">
             <result name="success">pages/login.jsp</result>
             <result name="input">pages/register.jsp</result>
             <result name="error">pages/error.jsp</result>
         </action>
 
+        <!-- action's name used by AuthenticationInterceptor  -->
         <action name="login" class="project.app.action.Login" method="execute">
             <result name="success">pages/login.jsp</result>
         </action>
 
+        <!-- action's name used by AuthenticationInterceptor  -->
         <action name="loginAccount" class="project.app.action.Login" method="loginAccount">
             <result name="regular" type="redirectAction">catalog</result>
             <result name="admin" type="redirectAction">
@@ -83,13 +91,42 @@
         </action>
     </package>
 
-    <package name="rulesFetchUser" namespace="/user" extends="struts-default">
+    <package name="rulesFetchBook" namespace="/" extends="globalsPackage">
 		<interceptors>
 
+			<interceptor name="authenticationInterceptor"
+				class="project.app.interceptor.AuthenticationInterceptor">
+            </interceptor>
 			<interceptor name="rulesInterceptor"
 				class="project.app.interceptor.RulesInterceptor" />
 
 			<interceptor-stack name="rulesFetchStack">
+                <interceptor-ref name="authenticationInterceptor" />
+				<interceptor-ref name="defaultStack" />
+                <interceptor-ref name="rulesInterceptor" />
+			</interceptor-stack>
+
+		</interceptors>
+
+		<default-interceptor-ref name="rulesFetchStack" />
+
+        <action name="book" class="project.app.action.Book" method="execute">
+            <result name="success">pages/book.jsp</result>
+        </action>
+
+    </package>
+
+    <package name="rulesFetchUser" namespace="/user" extends="globalsPackage">
+		<interceptors>
+
+			<interceptor name="authenticationInterceptor"
+				class="project.app.interceptor.AuthenticationInterceptor">
+            </interceptor>
+			<interceptor name="rulesInterceptor"
+				class="project.app.interceptor.RulesInterceptor" />
+
+			<interceptor-stack name="rulesFetchStack">
+                <interceptor-ref name="authenticationInterceptor" />
 				<interceptor-ref name="defaultStack" />
                 <interceptor-ref name="rulesInterceptor" />
 			</interceptor-stack>
@@ -105,7 +142,7 @@
 
     </package>
 
-    <package name="user" namespace="/user" extends="struts-default">
+    <package name="user" namespace="/user" extends="securePackage">
         <action name="cancelPendingCheckoutRequest" class="project.app.action.UserProfile" method="cancelPendingCheckoutRequest">
             <result name="success" type="redirectAction">
                 <param name="actionName">profile</param>
@@ -142,7 +179,7 @@
         </action>
     </package>
 
-    <package name="admin" namespace="/admin" extends="struts-default">
+    <package name="admin" namespace="/admin" extends="securePackage">
 		<action name="dashboard" class="project.app.action.AdminPanel">
 			<result name="success">pages/dashboard.jsp</result>
 			<result name="error">pages/error.jsp</result>
@@ -203,7 +240,7 @@
 		</action>
 	</package>
 
-    <package name="adminBook" namespace="/admin/book" extends="struts-default">
+    <package name="adminBook" namespace="/admin/book" extends="securePackage">
 		<action name="getBookEntryById" class="project.app.action.AdminBookEntry" method="getBookEntryById">
 			<result name="success">pages/bookEntry.jsp</result>
             <result name="error">pages/error.jsp</result>
@@ -273,7 +310,7 @@
 		</action>        
 	</package>
 
-    <package name="adminCheckout" namespace="/admin/checkout" extends="struts-default">
+    <package name="adminCheckout" namespace="/admin/checkout" extends="securePackage">
         <action name="checkoutRecordForm" class="project.app.action.AdminCheckoutRecord" method="checkoutRecordForm">
 			<result name="success">pages/checkoutRecord.jsp</result>
             <result name="error">pages/error.jsp</result>
@@ -309,7 +346,7 @@
         </action>
     </package>
 
-    <package name="adminCheckin" namespace="/admin/checkin" extends="struts-default">
+    <package name="adminCheckin" namespace="/admin/checkin" extends="securePackage">
         <action name="checkinCheckoutRecord" class="project.app.action.AdminEditCheckoutRecord" method="checkinCheckoutRecord">
             <result name="success" type="redirectAction">
                 <param name="actionName">manageCheckoutRecords</param>
@@ -319,14 +356,14 @@
         </action>
     </package>
 
-    <package name="adminUserView" namespace="/admin/user" extends="struts-default">
+    <package name="adminUserView" namespace="/admin/user" extends="securePackage">
         <action name="userView" class="project.app.action.AdminUserView" method="execute">
             <result name="success">pages/view.jsp</result>
             <result name="error">pages/error.jsp</result>
         </action>
     </package>
 
-    <package name="adminRule" namespace="/admin/rule" extends="struts-default">
+    <package name="adminRule" namespace="/admin/rule" extends="securePackage">
         <action name="ruleForm" class="project.app.action.AdminRule" method="ruleForm">
 			<result name="success">pages/rule.jsp</result>
             <result name="error">pages/error.jsp</result>


### PR DESCRIPTION
Non admin-accounts now redirect to catalog when trying to access /admin namespaces. Additionally, also made it so that if no user is detected, it will always reload to the index (where they can choose to register or log in) no matter the initial url.